### PR TITLE
Fix button calls and implement addFieldToForm

### DIFF
--- a/components/CreateEmptyListField.js
+++ b/components/CreateEmptyListField.js
@@ -3,7 +3,7 @@ import { createButton } from './Button.js';
 import { createFieldCreationSection } from './FieldCreationSection.js';
 
 export function createEmptyListField(parentElement, parentKey) {
-    const addButton = createButton(`Adicionar novo item em ${parentKey || 'root'}`, 'Adicionar item', () => {
+    const addButton = createButton(`Adicionar novo item em ${parentKey || 'root'}`, (event) => {
         event.preventDefault();
         createFieldCreationSection(parentElement, parentKey);
     });

--- a/components/CreateListField.js
+++ b/components/CreateListField.js
@@ -6,6 +6,7 @@ import { createCheckboxField } from './CheckboxField.js';
 import { createObjectFields } from './CreateObjectField.js';
 import { createInputField } from './InputField.js';
 import { createLabel } from './Label.js';
+import { createFieldCreationSection } from './FieldCreationSection.js';
 
 export function createListFields(parentElement, parentKey, value) {
     const fieldContainer = document.createElement('div');
@@ -50,7 +51,7 @@ function createAddFieldButton(parentElement, parentKey) {
     const addButton = document.createElement('button');
     addButton.type = 'button';
     addButton.textContent = `Adicionar novo campo em ${parentKey || 'root'}`;
-    addButton.addEventListener('click', () => {
+    addButton.addEventListener('click', (event) => {
         event.preventDefault();
         createFieldCreationSection(parentElement, parentKey);
     });

--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -35,7 +35,7 @@ export function createEditableLink(fieldId, text, isIndex) {
                     if (newName) {
                         document.querySelectorAll(`[data-key=${updatedFieldId}]`).forEach(element => {
                             let newFieldId = newElementInfos(element, updatedFieldId, newName);
-                            RuntimeDatabase.update(fieldId,)
+                            RuntimeDatabase.update(fieldId, newFieldId);
                         });
                         buttonDiv.remove();
                     }

--- a/components/FieldCreationSection.js
+++ b/components/FieldCreationSection.js
@@ -1,5 +1,9 @@
 // components/FieldCreationSection.js
 import { createButton } from './Button.js';
+import { createLabel } from './Label.js';
+import { createInputField } from './InputField.js';
+import { createObjectFields } from './CreateObjectField.js';
+import { createListFields } from './CreateListField.js';
 
 export function createFieldCreationSection(parentElement, parentKey = '') {
     const section = document.createElement('div');
@@ -7,7 +11,7 @@ export function createFieldCreationSection(parentElement, parentKey = '') {
 
     const typeSelect = createTypeSelect();
     const nameInput = createNameInput();
-    const saveButton = createButton('Salvar', 'Salvar campo', () => {
+    const saveButton = createButton('Salvar', (event) => {
         event.preventDefault();
         const fieldType = typeSelect.value;
         const fieldName = nameInput.value.trim();
@@ -18,7 +22,7 @@ export function createFieldCreationSection(parentElement, parentKey = '') {
             alert('Nome do campo não pode estar vazio');
         }
     });
-    const cancelButton = createButton('Cancelar', 'Cancelar criação', () => {
+    const cancelButton = createButton('Cancelar', () => {
         section.remove();
     });
 
@@ -47,4 +51,38 @@ function createNameInput() {
     nameInput.type = 'text';
     nameInput.placeholder = 'Nome do campo';
     return nameInput;
+}
+
+export function addFieldToForm(parentElement, parentKey, fieldName, fieldType) {
+    const container = document.createElement('div');
+    const fieldId = parentKey ? `${parentKey}__FIELD__${fieldName}` : fieldName;
+    const label = createLabel(fieldId, fieldName);
+    container.appendChild(label);
+
+    let input;
+    switch (fieldType) {
+        case 'boolean':
+            input = createInputField(fieldId, false, 'boolean');
+            break;
+        case 'number':
+            input = createInputField(fieldId, 0, 'number');
+            break;
+        case 'string':
+            input = createInputField(fieldId, '', 'string');
+            break;
+        case 'object':
+            createObjectFields(container, fieldId, {});
+            break;
+        case 'list':
+            createListFields(container, fieldId, []);
+            break;
+        default:
+            input = createInputField(fieldId, '', 'string');
+    }
+
+    if (input) {
+        container.appendChild(input);
+    }
+
+    parentElement.appendChild(container);
 }

--- a/components/formGenerator.js
+++ b/components/formGenerator.js
@@ -43,9 +43,9 @@ export function generateFormFields(jsonObject, parentElement, parentKey = '') {
 }
 
 function createAddFieldButton(parentElement, parentKey) {
-    const addButton = createButton(`Adicionar novo campo em ${parentKey || 'root'}`, () => {
+    const addButton = createButton(`Adicionar novo campo em ${parentKey || 'root'}`, (event) => {
         event.preventDefault();
-        createFieldCreationSection(parentElement, parentKey);Element
+        createFieldCreationSection(parentElement, parentKey);
     });
     parentElement.appendChild(addButton);
 }


### PR DESCRIPTION
## Summary
- call `createButton` with 2 params everywhere
- fix use of `event` argument in click handlers
- ensure CreateListField imports `createFieldCreationSection`
- implement `addFieldToForm` helper to actually append fields
- correct `RuntimeDatabase.update` call

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882ca2679f8832eb694950acac95360