### PR TITLE
Fix label link with index support

### DIFF
--- a/components/Label.js
+++ b/components/Label.js
@@ -4,7 +4,7 @@ import { createEditableLink } from './EditableLink.js';
 export function createLabel(fieldId, text, isIndex) {
     const label = document.createElement('label');
     label.setAttribute('for', fieldId);
-    const link = createEditableLink(fieldId, text);
+    const link = createEditableLink(fieldId, text, isIndex);
     label.appendChild(link);
     return label;
 }


### PR DESCRIPTION
## Summary
- pass `isIndex` to `createEditableLink` from `createLabel`

## Testing
- `node verify_isIndex.js` *(shows rename/delete buttons appear)*

------
https://chatgpt.com/codex/tasks/task_e_68856663a384832ea15dd984f083703b