### PR TITLE
Fix array item field ids

### DIFF
--- a/components/CreateListField.js
+++ b/components/CreateListField.js
@@ -26,13 +26,13 @@ export function createListFields(parentElement, parentKey, value) {
 
     value.forEach((item, index) => {
         const arrayFieldContainer = document.createElement('div');
-        const arrayFieldId = `${parentKey}${index}`;
-        const arrayLabel = createLabel(arrayFieldId, `${arrayFieldId.split('__FIELD__').pop()}`, true);
+        const arrayFieldId = `${parentKey}__FIELD__${index}`;
+        const arrayLabel = createLabel(arrayFieldId, `${index}`, true);
         arrayFieldContainer.appendChild(arrayLabel);
 
         let input;
         if (typeof item === 'object') {
-            createObjectFields(arrayFieldContainer, `${parentKey}[${index}]`, item);
+            createObjectFields(arrayFieldContainer, `${parentKey}__FIELD__${index}`, item);
         } else {
             input = createInputField(arrayFieldId, item, typeof item);
             arrayFieldContainer.appendChild(input);


### PR DESCRIPTION
## Summary
- handle array item field IDs uniformly
- pass cleaned IDs to `createObjectFields`
- show numeric index labels for array items

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688566683efc832eba0bf0dd22a3b431