### PR TITLE
Fix list id renaming

### DIFF
--- a/components/CreateListField.js
+++ b/components/CreateListField.js
@@ -26,13 +26,13 @@ export function createListFields(parentElement, parentKey, value) {
 
     value.forEach((item, index) => {
         const arrayFieldContainer = document.createElement('div');
-        const arrayFieldId = `${parentKey}${index}`;
-        const arrayLabel = createLabel(arrayFieldId, `${arrayFieldId.split('__FIELD__').pop()}`, true);
+        const arrayFieldId = `${parentKey}__FIELD__${index}`;
+        const arrayLabel = createLabel(arrayFieldId, `${index}`, true);
         arrayFieldContainer.appendChild(arrayLabel);
 
         let input;
         if (typeof item === 'object') {
-            createObjectFields(arrayFieldContainer, `${parentKey}[${index}]`, item);
+            createObjectFields(arrayFieldContainer, arrayFieldId, item);
         } else {
             input = createInputField(arrayFieldId, item, typeof item);
             arrayFieldContainer.appendChild(input);

--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -29,14 +29,12 @@ export function createEditableLink(fieldId, text, isIndex) {
                 const editButton = document.createElement('button');
                 editButton.textContent = 'Trocar Nome';
                 editButton.addEventListener('click', function firstClick() {
-                    const updatedFieldId = returnCorrectField(fieldId);
-                    const updatedText = updatedFieldId.split('__FIELD__').pop();
+                    const currentId = returnCorrectField(fieldId);
+                    const updatedText = currentId.split('__FIELD__').pop();
                     const newName = prompt('Digite o novo nome do campo:', updatedText);
                     if (newName) {
-                        document.querySelectorAll(`[data-key=${updatedFieldId}]`).forEach(element => {
-                            let newFieldId = newElementInfos(element, updatedFieldId, newName);
-                            RuntimeDatabase.update(fieldId,)
-                        });
+                        renameListItem(link.closest('div'), currentId, newName);
+                        RuntimeDatabase.update(fieldId, currentId.replace(updatedText, newName));
                         buttonDiv.remove();
                     }
                     editButton.removeEventListener('click', firstClick);
@@ -54,13 +52,43 @@ export function createEditableLink(fieldId, text, isIndex) {
     return link;
 }
 
-function newElementInfos(element, oldFieldId, newName) {
-    element.textContent = newName;
-    element.setAttribute('aria-label', newName);
-    const oldDataSetKeyEnd = oldFieldId.split('__FIELD__').pop();
-    const newDataSetKey = oldFieldId.split(oldDataSetKeyEnd)[0] + newName;
-    element.dataset.key = newDataSetKey;
-    return newDataSetKey;
+function renameListItem(container, oldFieldId, newName) {
+    const parentPath = oldFieldId.split('__FIELD__').slice(0, -1).join('__FIELD__');
+    const newFieldId = `${parentPath}__FIELD__${newName}`;
+
+    container.querySelectorAll('[data-key]').forEach(el => {
+        if (el.dataset.key.startsWith(oldFieldId)) {
+            el.dataset.key = el.dataset.key.replace(oldFieldId, newFieldId);
+            if (el.textContent === oldFieldId.split('__FIELD__').pop()) {
+                el.textContent = newName;
+            }
+        }
+    });
+
+    container.querySelectorAll('[id]').forEach(el => {
+        if (el.id.startsWith(oldFieldId)) {
+            el.id = el.id.replace(oldFieldId, newFieldId);
+        }
+    });
+
+    container.querySelectorAll('label').forEach(label => {
+        const forAttr = label.getAttribute('for');
+        if (forAttr && forAttr.startsWith(oldFieldId)) {
+            label.setAttribute('for', forAttr.replace(oldFieldId, newFieldId));
+        }
+    });
+
+    updateRuntimeDatabaseIds(oldFieldId, newFieldId);
+}
+
+function updateRuntimeDatabaseIds(oldPrefix, newPrefix) {
+    const entries = RuntimeDatabase.getAll();
+    Object.keys(entries).forEach(key => {
+        const value = entries[key];
+        if (value.startsWith(oldPrefix)) {
+            RuntimeDatabase.update(key, value.replace(oldPrefix, newPrefix));
+        }
+    });
 }
 
 function returnCorrectField(fieldId) {

--- a/components/Label.js
+++ b/components/Label.js
@@ -1,10 +1,10 @@
 // components/Label.js
 import { createEditableLink } from './EditableLink.js';
 
-export function createLabel(fieldId, text, isIndex) {
+export function createLabel(fieldId, text, isIndex = false) {
     const label = document.createElement('label');
     label.setAttribute('for', fieldId);
-    const link = createEditableLink(fieldId, text);
+    const link = createEditableLink(fieldId, text, isIndex);
     label.appendChild(link);
     return label;
 }


### PR DESCRIPTION
## Summary
- keep list IDs consistent when generating forms
- allow renaming of list indexes with nested elements
- propagate updated IDs in runtime database

## Testing
- `node -e "import('./components/EditableLink.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`
- `node -e "import('./components/CreateListField.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`
- `node -e "import('./components/Label.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_6885666ad564832e83d1cad9ab48c7c6