### PR TITLE
Fix root key generation

### DIFF
--- a/components/FormInitializer.js
+++ b/components/FormInitializer.js
@@ -31,7 +31,7 @@ function handleGenerateForm(jsonInput, form) {
         logMessage('Conteúdo do formulário apagado.');
         logMessage('Gerando novos campos no formulário. Enviando objeto json e formulário html.');
         
-        generateFormFields(jsonObject, form, 'root');
+        generateFormFields(jsonObject, form, '');
     } catch (e) {
         alert('JSON inválido');
         console.error(e);

--- a/components/formGenerator.js
+++ b/components/formGenerator.js
@@ -12,23 +12,24 @@ export function generateFormFields(jsonObject, parentElement, parentKey = '') {
         if (jsonObject.hasOwnProperty(key)) {
             const value = jsonObject[key];
             const fieldContainer = document.createElement('div');
-        const label = createLabel(`${parentKey}__FIELD__${key}`, key);
+            const fieldId = parentKey ? `${parentKey}__FIELD__${key}` : key;
+            const label = createLabel(fieldId, key);
             fieldContainer.appendChild(label);
 
             let input;
             if (typeof value === 'boolean') {
-                input = createInputField(`${parentKey}__FIELD__${key}`, value, 'boolean');
+                input = createInputField(fieldId, value, 'boolean');
             } else if (typeof value === 'number') {
-                input = createInputField(`${parentKey}__FIELD__${key}`, value, 'number');
+                input = createInputField(fieldId, value, 'number');
             } else if (typeof value === 'string') {
-                input = createInputField(`${parentKey}__FIELD__${key}`, value, 'string');
+                input = createInputField(fieldId, value, 'string');
             } else if (typeof value === 'object' && !Array.isArray(value)) {
-                createObjectFields(fieldContainer, `${parentKey}__FIELD__${key}`, value);
+                createObjectFields(fieldContainer, fieldId, value);
             } else if (Array.isArray(value)) {
                 if (value.length > 0) {
-                    createListFields(fieldContainer, `${parentKey}__FIELD__${key}`, value);
+                    createListFields(fieldContainer, fieldId, value);
                 } else {
-                    createEmptyListField(fieldContainer, `${parentKey}__FIELD__${key}`);
+                    createEmptyListField(fieldContainer, fieldId);
                 }
             }
 


### PR DESCRIPTION
## Summary
- build top-level ids without leading `__FIELD__`
- remove `'root'` when generating forms

## Testing
- `node test.js` *(fails: file removed)*

------
https://chatgpt.com/codex/tasks/task_e_6885929e2d74832e84e25c3de2d20dfd