### PR TITLE
Improve add field button labels

### DIFF
--- a/components/CreateEmptyListField.js
+++ b/components/CreateEmptyListField.js
@@ -3,7 +3,8 @@ import { createButton } from './Button.js';
 import { createFieldCreationSection } from './FieldCreationSection.js';
 
 export function createEmptyListField(parentElement, parentKey) {
-    const addButton = createButton(`Adicionar novo item em ${parentKey || 'root'}`, (event) => {
+    const displayName = parentKey ? parentKey.split('__FIELD__').pop() : 'root';
+    const addButton = createButton(`Adicionar novo item em ${displayName}`, (event) => {
         event.preventDefault();
         createFieldCreationSection(parentElement, parentKey);
     });

--- a/components/CreateListField.js
+++ b/components/CreateListField.js
@@ -50,7 +50,8 @@ export function createListFields(parentElement, parentKey, value) {
 function createAddFieldButton(parentElement, parentKey) {
     const addButton = document.createElement('button');
     addButton.type = 'button';
-    addButton.textContent = `Adicionar novo campo em ${parentKey || 'root'}`;
+    const displayName = parentKey ? parentKey.split('__FIELD__').pop() : 'root';
+    addButton.textContent = `Adicionar novo campo em ${displayName}`;
     addButton.addEventListener('click', (event) => {
         event.preventDefault();
         createFieldCreationSection(parentElement, parentKey);

--- a/components/FieldHandlers.js
+++ b/components/FieldHandlers.js
@@ -54,6 +54,7 @@ export function updateButtonLabels(parentElement) {
     const buttons = parentElement.querySelectorAll('button');
     buttons.forEach(button => {
         const parentKey = button.dataset.parentKey;
-        button.textContent = `Adicionar novo campo em ${parentKey || 'root'}`;
+        const displayName = parentKey ? parentKey.split('__FIELD__').pop() : 'root';
+        button.textContent = `Adicionar novo campo em ${displayName}`;
     });
 }

--- a/components/formGenerator.js
+++ b/components/formGenerator.js
@@ -43,7 +43,8 @@ export function generateFormFields(jsonObject, parentElement, parentKey = '') {
 }
 
 function createAddFieldButton(parentElement, parentKey) {
-    const addButton = createButton(`Adicionar novo campo em ${parentKey || 'root'}`, (event) => {
+    const displayName = parentKey ? parentKey.split('__FIELD__').pop() : 'root';
+    const addButton = createButton(`Adicionar novo campo em ${displayName}`, (event) => {
         event.preventDefault();
         createFieldCreationSection(parentElement, parentKey);
     });


### PR DESCRIPTION
## Summary
- clean up labels for add-field buttons by showing only the current parent name

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688592a30bf4832eafcb8cf35437eb04