### PR TITLE
Add logs for expand/collapse and field operations

### DIFF
--- a/components/CreateListField.js
+++ b/components/CreateListField.js
@@ -7,6 +7,7 @@ import { createObjectFields } from './CreateObjectField.js';
 import { createInputField } from './InputField.js';
 import { createLabel } from './Label.js';
 import { createFieldCreationSection } from './FieldCreationSection.js';
+import { logMessage } from './LogLevelComponent.js';
 
 export function createListFields(parentElement, parentKey, value) {
     const fieldContainer = document.createElement('div');
@@ -21,6 +22,11 @@ export function createListFields(parentElement, parentKey, value) {
 
     const nestedContainer = document.createElement('div');
     nestedContainer.style.display = 'none';
+    nestedContainer.addEventListener('click', (event) => {
+        if (event.target.textContent === 'Deletar') {
+            logMessage(`Item removido de ${parentKey.split('__FIELD__').pop()}`);
+        }
+    });
 
     fieldContainer.appendChild(toggleButton);
     fieldContainer.appendChild(nestedContainer);
@@ -40,6 +46,7 @@ export function createListFields(parentElement, parentKey, value) {
         }
 
         nestedContainer.appendChild(arrayFieldContainer);
+        logMessage(`Item ${index} adicionado em ${parentKey.split('__FIELD__').pop()}`);
     });
 
     createAddFieldButton(nestedContainer, parentKey);
@@ -54,6 +61,7 @@ function createAddFieldButton(parentElement, parentKey) {
     addButton.textContent = `Adicionar novo campo em ${displayName}`;
     addButton.addEventListener('click', (event) => {
         event.preventDefault();
+        logMessage(`Adicionar novo item em ${displayName}`);
         createFieldCreationSection(parentElement, parentKey);
     });
     parentElement.appendChild(addButton);

--- a/components/CreateObjectField.js
+++ b/components/CreateObjectField.js
@@ -2,6 +2,7 @@
 import RuntimeDatabase from './runtimeDatabase.js';
 import { createToggleButton } from './ToggleButton.js';
 import { generateFormFields } from './formGenerator.js';
+import { logMessage } from './LogLevelComponent.js';
 
 export function createObjectFields(parentElement, parentKey, value) {
     RuntimeDatabase.create(parentKey);
@@ -17,9 +18,15 @@ export function createObjectFields(parentElement, parentKey, value) {
 
     const nestedContainer = document.createElement('div');
     nestedContainer.style.display = 'none';
+    nestedContainer.addEventListener('click', (event) => {
+        if (event.target.textContent === 'Deletar') {
+            logMessage(`Campo removido de ${parentKey.split('__FIELD__').pop()}`);
+        }
+    });
 
     fieldContainer.appendChild(toggleButton);
     generateFormFields(value, nestedContainer, parentKey);
+    logMessage(`Campos adicionados ao objeto ${parentKey.split('__FIELD__').pop()}`);
     fieldContainer.appendChild(nestedContainer);
 
     parentElement.appendChild(fieldContainer);

--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -1,5 +1,6 @@
 // components/EditableLink.js
 import RuntimeDatabase from './runtimeDatabase.js';
+import { logMessage } from './LogLevelComponent.js';
 
 export function createEditableLink(fieldId, text, isIndex) {
     const link = document.createElement('a');
@@ -22,6 +23,7 @@ export function createEditableLink(fieldId, text, isIndex) {
             deleteButton.addEventListener('click', function () {
                 if (confirm(`Deseja realmente deletar o campo ${text}?`)) {
                     link.closest('div').remove();
+                    logMessage(`Campo ${text} deletado`);
                 }
             });
             
@@ -38,6 +40,7 @@ export function createEditableLink(fieldId, text, isIndex) {
                             let newFieldId = updateElementIds(element.closest('div'), updatedFieldId, newName);
                             RuntimeDatabase.update(fieldId, newFieldId);
                         });
+                        logMessage(`Campo ${updatedText} renomeado para ${newName}`);
                         buttonDiv.remove();
                     }
                     editButton.removeEventListener('click', firstClick);

--- a/components/FieldCreationSection.js
+++ b/components/FieldCreationSection.js
@@ -4,10 +4,14 @@ import { createLabel } from './Label.js';
 import { createInputField } from './InputField.js';
 import { createObjectFields } from './CreateObjectField.js';
 import { createListFields } from './CreateListField.js';
+import { logMessage } from './LogLevelComponent.js';
 
 export function createFieldCreationSection(parentElement, parentKey = '') {
     const section = document.createElement('div');
     section.classList.add('field-creation-section');
+
+    const localName = parentKey ? parentKey.split('__FIELD__').pop() : 'root';
+    logMessage(`Abrindo seção de criação em ${localName}`);
 
     const typeSelect = createTypeSelect();
     const nameInput = createNameInput();
@@ -17,12 +21,15 @@ export function createFieldCreationSection(parentElement, parentKey = '') {
         const fieldName = nameInput.value.trim();
         if (fieldName) {
             addFieldToForm(parentElement, parentKey, fieldName, fieldType);
+            logMessage(`Campo ${fieldName} criado em ${localName}`);
             section.remove();
         } else {
+            logMessage('Erro ao criar campo: nome vazio');
             alert('Nome do campo não pode estar vazio');
         }
     });
     const cancelButton = createButton('Cancelar', () => {
+        logMessage('Criação de campo cancelada');
         section.remove();
     });
 

--- a/components/ToggleButton.js
+++ b/components/ToggleButton.js
@@ -1,10 +1,19 @@
 // components/ToggleButton.js
+import { logMessage } from './LogLevelComponent.js';
+
 export function createToggleButton(text, parentKey, onClick) {
     parentKey = parentKey.split('__FIELD__').pop();
     const button = document.createElement('button');
     button.textContent = `${text} ${parentKey}`;
     button.setAttribute('type', 'button');
     button.setAttribute('aria-label', button.textContent);
-    button.addEventListener('click', onClick);
+    const tipo = text.toLowerCase().includes('lista') ? 'lista' : 'objeto';
+    button.dataset.toggleType = tipo;
+    button.dataset.toggleName = parentKey;
+    button.addEventListener('click', () => {
+        onClick();
+        const estado = button.textContent === 'Expandir' ? 'recolhido' : 'expandido';
+        logMessage(`${tipo.charAt(0).toUpperCase() + tipo.slice(1)} ${parentKey} ${estado}`);
+    });
     return button;
 }

--- a/components/jsonUpdater.js
+++ b/components/jsonUpdater.js
@@ -1,5 +1,8 @@
 // components/jsonUpdater.js
+import { logMessage } from './LogLevelComponent.js';
+
 export function updateJsonFromForm(form) {
+    logMessage('Iniciando atualização do JSON');
     const updatedJson = {};
     const elements = form.querySelectorAll('input, select, textarea');
     elements.forEach(element => {
@@ -16,6 +19,7 @@ export function updateJsonFromForm(form) {
             }
         });
     });
+    logMessage('JSON atualizado com sucesso');
     return updatedJson;
 }
 


### PR DESCRIPTION
## Summary
- log list/object toggle state
- log creation section actions
- track item creation/removal for lists and objects
- log rename and delete actions
- note JSON update start/finish

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688818379f34832eb9921b6b9559a49d