### PR TITLE
Fix rename button condition

### DIFF
--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -25,7 +25,7 @@ export function createEditableLink(fieldId, text, isIndex) {
                 }
             });
             
-            if (isIndex === true) {
+            if (isIndex === false) {
                 const editButton = document.createElement('button');
                 editButton.textContent = 'Trocar Nome';
                 editButton.addEventListener('click', function firstClick() {


### PR DESCRIPTION
## Summary
- invert the isIndex condition when showing the rename button

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6888183a46a0832e8d026ead97c62ceb