### PR TITLE
Corrige atualização de botões após renomear

### DIFF
--- a/components/CreateEmptyListField.js
+++ b/components/CreateEmptyListField.js
@@ -10,5 +10,6 @@ export function createEmptyListField(parentElement, parentKey) {
         event.preventDefault();
         createFieldCreationSection(parentElement, parentKey, parentElement.dataset.itemType || null);
     });
+    addButton.dataset.parentKey = parentKey;
     parentElement.appendChild(addButton);
 }

--- a/components/CreateListField.js
+++ b/components/CreateListField.js
@@ -82,5 +82,6 @@ function createAddFieldButton(parentElement, parentKey) {
         logMessage(`Adicionar novo item em ${displayName}`);
         createFieldCreationSection(parentElement, parentKey, parentElement.dataset.itemType || null);
     });
+    addButton.dataset.parentKey = parentKey;
     parentElement.appendChild(addButton);
 }

--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -61,6 +61,8 @@ export function createEditableLink(fieldId, text, isIndex) {
 function updateElementIds(container, oldFieldId, newName) {
     const parentPath = oldFieldId.split('__FIELD__').slice(0, -1).join('__FIELD__');
     const newFieldId = `${parentPath}__FIELD__${newName}`;
+    const oldDisplay = oldFieldId.split('__FIELD__').join('.');
+    const newDisplay = newFieldId.split('__FIELD__').join('.');
 
     container.querySelectorAll('[data-key]').forEach(el => {
         if (el.dataset.key.startsWith(oldFieldId)) {
@@ -68,6 +70,24 @@ function updateElementIds(container, oldFieldId, newName) {
             if (el.textContent === oldFieldId.split('__FIELD__').pop()) {
                 el.textContent = newName;
             }
+        }
+    });
+
+    container.querySelectorAll('[data-toggle-name]').forEach(btn => {
+        const toggleName = btn.dataset.toggleName;
+        if (toggleName && toggleName.startsWith(oldFieldId)) {
+            btn.dataset.toggleName = toggleName.replace(oldFieldId, newFieldId);
+            btn.textContent = btn.textContent.replace(oldDisplay, newDisplay);
+            btn.setAttribute('aria-label', btn.textContent);
+        }
+    });
+
+    container.querySelectorAll('[data-parent-key]').forEach(btn => {
+        const parentKey = btn.dataset.parentKey;
+        if (parentKey && parentKey.startsWith(oldFieldId)) {
+            btn.dataset.parentKey = parentKey.replace(oldFieldId, newFieldId);
+            btn.textContent = btn.textContent.replace(oldDisplay, newDisplay);
+            btn.setAttribute('aria-label', btn.textContent);
         }
     });
 

--- a/components/formGenerator.js
+++ b/components/formGenerator.js
@@ -50,5 +50,6 @@ function createAddFieldButton(parentElement, parentKey) {
         event.preventDefault();
         createFieldCreationSection(parentElement, parentKey);
     });
+    addButton.dataset.parentKey = parentKey;
     parentElement.appendChild(addButton);
 }


### PR DESCRIPTION
## Resumo
- atualiza IDs e textos de botões ao renomear campos
- registra o `parentKey` em botões de adição para atualizar seus rótulos
- garante que atributos `toggle-name` também são ajustados

## Testes
- `node renameTest.js` (script temporário) para verificar atualização de texto e atributos

------
https://chatgpt.com/codex/tasks/task_e_688bffda03bc832ea817b14db8496987