### PR TITLE
Correção de rótulos ao renomear checkboxes

### DIFF
--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -84,6 +84,14 @@ function updateElementIds(container, oldFieldId, newName) {
         }
     });
 
+    container.querySelectorAll('input[type="checkbox"]').forEach(input => {
+        if (input.id && input.id.startsWith(oldFieldId)) {
+            input.id = input.id.replace(oldFieldId, newFieldId);
+            const labelName = newFieldId.split('__FIELD__').pop();
+            input.setAttribute('aria-label', `${labelName} ${input.checked ? 'true' : 'false'}`);
+        }
+    });
+
     updateRuntimeDatabaseIds(oldFieldId, newFieldId);
 }
 


### PR DESCRIPTION
## Resumo
- ajusta `updateElementIds` para atualizar IDs de checkboxes e seus `aria-label`

## Testes
- `node -e "require('./components/EditableLink.js')"`

------
https://chatgpt.com/codex/tasks/task_e_688bffdbcf20832e8e19567c96a7d873