### PR TITLE
Corrige recarregamento e renomeação contínua

### DIFF
--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -20,6 +20,7 @@ export function createEditableLink(fieldId, text, isIndex) {
 
             const deleteButton = document.createElement('button');
             deleteButton.textContent = 'Deletar';
+            deleteButton.setAttribute('type', 'button');
             deleteButton.addEventListener('click', function () {
                 if (confirm(`Deseja realmente deletar o campo ${text}?`)) {
                     link.closest('div').remove();
@@ -30,6 +31,7 @@ export function createEditableLink(fieldId, text, isIndex) {
             if (isIndex === false) {
                 const editButton = document.createElement('button');
                 editButton.textContent = 'Trocar Nome';
+                editButton.setAttribute('type', 'button');
                 editButton.addEventListener('click', function firstClick() {
                     const currentId = returnCorrectField(fieldId);
                     const updatedFieldId = currentId;
@@ -85,6 +87,8 @@ function updateElementIds(container, oldFieldId, newName) {
     });
 
     updateRuntimeDatabaseIds(oldFieldId, newFieldId);
+
+    return newFieldId;
 }
 
 function updateRuntimeDatabaseIds(oldPrefix, newPrefix) {


### PR DESCRIPTION
## Summary
- impedir que botões de edição e remoção submetam o formulário
- retornar o novo id ao atualizar elementos

## Testing
- `npm install jsdom@22`
- `node rename_test.js` *(produziu `obj__FIELD__novo2`)*

------
https://chatgpt.com/codex/tasks/task_e_688bffdd3adc832ea783d9d17237cea8