### PR TITLE
Corrige atualização de botões ao renomear listas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ As principais funcionalidades são:
 - `CreateListField.js` – Gera formulários aninhados para valores de array e inclui um auxiliar para anexar novas entradas de lista.
 - `CreateEmptyListField.js` – Fornece um botão para adicionar um item a uma lista vazia.
 - `Label.js` – Produz um elemento `<label>` contendo um link editável.
-- `EditableLink.js` – Cria um link que exibe controles de edição/exclusão para nomes de campos; utiliza `runtimeDatabase` para resolver IDs.
+ - `EditableLink.js` – Cria um link que exibe controles de edição/exclusão para nomes de campos; utiliza `runtimeDatabase` para resolver IDs. A função `updateElementIds` também atualiza botões de expansão criados por `ToggleButton.js`.
 - `FieldCreationSection.js` – Interface para criar novos campos (seletor de tipo, entrada de nome, botões Salvar/Cancelar).
 - `FieldHandlers.js` – Funções utilitárias para anexar ouvintes aos elementos criados acima.
 - `formGenerator.js` – Rotina principal que percorre um objeto JSON e constrói o conjunto completo de elementos do formulário recursivamente.

--- a/components/EditableLink.js
+++ b/components/EditableLink.js
@@ -19,6 +19,7 @@ export function createEditableLink(fieldId, text, isIndex) {
             buttonDiv.classList.add('edit-delete-buttons');
 
             const deleteButton = document.createElement('button');
+            deleteButton.type = 'button';
             deleteButton.textContent = 'Deletar';
             deleteButton.addEventListener('click', function () {
                 if (confirm(`Deseja realmente deletar o campo ${text}?`)) {
@@ -29,6 +30,7 @@ export function createEditableLink(fieldId, text, isIndex) {
             
             if (isIndex === false) {
                 const editButton = document.createElement('button');
+                editButton.type = 'button';
                 editButton.textContent = 'Trocar Nome';
                 editButton.addEventListener('click', function firstClick() {
                     const currentId = returnCorrectField(fieldId);
@@ -61,6 +63,8 @@ export function createEditableLink(fieldId, text, isIndex) {
 function updateElementIds(container, oldFieldId, newName) {
     const parentPath = oldFieldId.split('__FIELD__').slice(0, -1).join('__FIELD__');
     const newFieldId = `${parentPath}__FIELD__${newName}`;
+    const oldDisplayName = oldFieldId.split('__FIELD__').join('.');
+    const newDisplayName = newFieldId.split('__FIELD__').join('.');
 
     container.querySelectorAll('[data-key]').forEach(el => {
         if (el.dataset.key.startsWith(oldFieldId)) {
@@ -81,6 +85,14 @@ function updateElementIds(container, oldFieldId, newName) {
         const forAttr = label.getAttribute('for');
         if (forAttr && forAttr.startsWith(oldFieldId)) {
             label.setAttribute('for', forAttr.replace(oldFieldId, newFieldId));
+        }
+    });
+
+    container.querySelectorAll('button[data-toggle-name]').forEach(button => {
+        if (button.dataset.toggleName.startsWith(oldFieldId)) {
+            button.dataset.toggleName = button.dataset.toggleName.replace(oldFieldId, newFieldId);
+            button.textContent = button.textContent.replace(oldDisplayName, newDisplayName);
+            button.setAttribute('aria-label', `${button.textContent} ${button.dataset.toggleType} ${newDisplayName}`);
         }
     });
 


### PR DESCRIPTION
## Resumo
- impedir recarregamento ao trocar nome de campos
- atualizar `dataset.toggleName` e texto dos botões de expansão
- documentar nova lógica no **AGENTS.md**

## Testes
- `node --check components/EditableLink.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_688bffde415c832ebc1de2c3c69943a7